### PR TITLE
Tray icon fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Pomotroid is in its early stages, so feedback and contributions are welcome! :se
 - Customize times and number of rounds (persistent)
 - Charming timer alert sounds (optional)
 - Desktop notifications (optional)
+- Minimize to tray (optional)
 
 ### Roadmap
 :memo: Future plans for enhancements and development:
 - Auto-start timer option toggle
-- Minimize to tray
 
 ## Download
 Pomotroid is available for Windows 32/64, Mac OSX and Debian/Ubuntu flavored Linux.

--- a/src/renderer/components/drawer/Drawer-settings.vue
+++ b/src/renderer/components/drawer/Drawer-settings.vue
@@ -56,6 +56,7 @@ export default {
         key: 'minToTray',
         val: !this.minToTray
       }
+      ipcRenderer.send('toggle-minToTray', !this.minToTray)
       this.$store.dispatch('setSetting', payload)
       this.$store.dispatch('setViewState', payload)
     },


### PR DESCRIPTION
This (hopefully) finishes the existing work in the `minToTray` branch. Tested on Windows only.

Apart from a trivial icon path fix, the PR changes the tray icon behavior slightly. Previously, the tray icon was destroyed and re-created each time the window was displayed and minimized. This however doesn't play well with Windows as then the tray icon looses it's position in the tray and in my case keeps disappearing into the hidden icons box such that I have to drag it out again. Hence I changed the code so that the tray icon is always there if the option is enabled. I also added a context menu that appears via a right click, currently with the only option to exit the app.