### PR TITLE
Prevent timer from lagging behind

### DIFF
--- a/src/renderer/utils/timer.js
+++ b/src/renderer/utils/timer.js
@@ -8,27 +8,41 @@ export default class {
 
   start() {
     if (!this.timerInt) {
-      this.timerInt = setInterval(() => {
+      // we are not calling back on fixed seconds, but on fixed seconds plus this offset
+      const msOffset = new Date().getMilliseconds()
+
+      const timerLoop = () => {
         this.time += 1
         if (this.time >= this.totalSeconds) {
           this.pause()
           EventBus.$emit('timer-completed')
+          // return to prevent the next timeout
+          return
         } else {
           EventBus.$emit('timer-advanced', this.time, this.totalSeconds)
         }
-      }, 1000)
+
+        // compute how many ms to wait before the next call
+        // we do this because the callback takes time, so calling with 1000 ms of delay each time
+        // makes us lag behind after a bit
+        const computedTimeout = 1000 - (new Date().getMilliseconds() - msOffset)
+        this.timerInt = setTimeout(timerLoop, computedTimeout)
+      }
+
+      // first call is always in 1000 ms
+      this.timerInt = setTimeout(timerLoop, 1000)
       EventBus.$emit('timer-started')
     }
   }
 
   pause() {
-    clearInterval(this.timerInt)
+    clearTimeout(this.timerInt)
     delete this.timerInt
     EventBus.$emit('timer-paused')
   }
 
   reset() {
-    clearInterval(this.timerInt)
+    clearTimeout(this.timerInt)
     delete this.timerInt
     this.time = 0
     EventBus.$emit('timer-reset')


### PR DESCRIPTION
Implemented the timer with **setTimeout** instead of **setInterval** to control the delay between each calls and prevent accumulation of lag.

Instead of accumulating ~2 ms of lag on each interval, this method will keep the lag in check on the long run.
It cannot accumulate as each interval is calculated with the current lag in mind.

This change partially addresses #32 (window in background might still cause issues, so I can't say this alone will fix it).