### PR TITLE
Reimplemented timer using `requestAnimationFrame`

### DIFF
--- a/src/renderer/utils/timer.js
+++ b/src/renderer/utils/timer.js
@@ -46,7 +46,7 @@ export default class Timer {
           previous = now - carryMillis
 
           // add seconds as integers
-          time += flooredSeconds
+          this.time += flooredSeconds
 
           if (this.time >= this.totalSeconds) {
             this.pause()


### PR DESCRIPTION
## What it does
To fix #32, this PR implements the timer using the `requestAnimationFrame` API.

## Benefits
- High precision clock time since page load is used instead of system time (Date API)
- Low latency (~20ms no matter the timer total run time)
- In case of throttling, no seconds will be lost. No delay can accumulate over ~200ms

## Notes
if there is more than a second of throttling, more than 1 second can be added at once to the timer.
Currently in the PR, the `timer-advanced` event is only fired once (essentially "skipping seconds" from the perspective of someone listening to the event).
However, it can easily be implemented to fire an event for each passed seconds (all those events would fire at once).

Why `setTimeout` is not the way to go: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout
Credits to https://github.com/Splode/pomotroid/pull/41#issuecomment-494114345 for the tip.