### PR TITLE
Added counter for total sessions

### DIFF
--- a/src/renderer/components/timer/Timer-footer.vue
+++ b/src/renderer/components/timer/Timer-footer.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="Container Footer">
     <div class="Round-wrapper">
-      <p>{{ round + '/' + workRounds }}</p>
+      <p>{{ round + '/' + workRounds }} <span class="total-rounds">{{ totalRounds }}</span></p>
       <p
         class="TextButton"
         @click="callForReset"
@@ -146,6 +146,10 @@ export default {
       return this.$store.getters.round
     },
 
+    totalRounds() {
+      return this.$store.getters.totalRounds
+    },
+
     workRounds() {
       return this.$store.getters.workRounds
     },
@@ -274,5 +278,10 @@ export default {
       border-color: $colorRed;
     }
   }
+}
+
+.total-rounds {
+  color: #858c99;
+  font-size: .7rem;
 }
 </style>

--- a/src/renderer/components/timer/Timer-footer.vue
+++ b/src/renderer/components/timer/Timer-footer.vue
@@ -1,7 +1,7 @@
 <template>
   <section class="Container Footer">
     <div class="Round-wrapper">
-      <p>{{ round + '/' + workRounds }} <span class="total-rounds">{{ totalRounds }}</span></p>
+      <p>{{ round + '/' + workRounds }} <span class="total-rounds">({{ totalRounds }})</span></p>
       <p
         class="TextButton"
         @click="callForReset"

--- a/src/renderer/store/modules/Timer.js
+++ b/src/renderer/store/modules/Timer.js
@@ -2,6 +2,7 @@ import { localStore } from './index'
 import { defaults } from './../../utils/LocalStore'
 
 const state = {
+  totalRounds: 1,
   round: 1,
   workRounds: parseInt(localStore.get('workRounds')),
   timeLongBreak: parseInt(localStore.get('timeLongBreak')),
@@ -12,6 +13,9 @@ const state = {
 }
 
 const getters = {
+  totalRounds() {
+    return state.totalRounds
+  },
   round() {
     return state.round
   },
@@ -38,6 +42,7 @@ const getters = {
 const mutations = {
   INCREMENT_ROUND(state) {
     state.round += 1
+    state.totalRounds += 1
   },
 
   RESET_ROUND(state) {


### PR DESCRIPTION
Hi Chris,

As I mentioned in my email, I'm a big fan of your application. 

I added a small counter to keep track of how many Pomodoro sessions are completed. Not sure if this is something you or other users might find useful, but I find it helpful to have a rough idea of how I did that day. I thought of sharing (see screenshot below).

![total_sessions](https://user-images.githubusercontent.com/20051042/80923649-348c5400-8d85-11ea-898b-adf4238f8254.jpg)

Best,
Mihai