### PR TITLE
fix scoop install, increase max time to 90 minutes

### DIFF
--- a/pomotroid.json
+++ b/pomotroid.json
@@ -1,10 +1,10 @@
 {
-  "version": "0.7.0",
-  "bin": [["pomotroid-0.7.0-portable.exe", "pomotroid"]],
-  "url": "https://github.com/Splode/pomotroid/releases/download/v0.7.0/pomotroid-0.7.0-portable.exe",
-  "hash": "81401b70875f4c4df57d6f365700c4cd7aa1bd3d7ca66dec70380dcc73cd32f9",
+  "version": "0.7.1",
+  "bin": [["pomotroid-0.7.1-portable.exe", "pomotroid"]],
+  "url": "https://github.com/Splode/pomotroid/releases/download/v0.7.1/pomotroid-0.7.1-portable.exe",
+  "hash": "e5c696405483fa72bac24b525ba27775773ca265f10aaed091c926dbc2e7ae94",
   "description": "A simple and configurable Pomodoro timer. It aims to provide a visually-pleasing and reliable way to track productivity using the Pomodoro Technique.",
   "homepage": "https://github.com/splode/pomotroid",
   "license": "MIT",
-  "shortcuts": [["pomotroid-0.7.0-portable.exe", "Pomotroid"]]
+  "shortcuts": [["pomotroid-0.7.1-portable.exe", "Pomotroid"]]
 }

--- a/src/renderer/components/drawer/Drawer-timer.vue
+++ b/src/renderer/components/drawer/Drawer-timer.vue
@@ -106,7 +106,7 @@ export default {
       localTimeShortBreak: 0,
       localTimeWork: 0,
       localWorkRounds: 0,
-      maxTime: 60,
+      maxTime: 90,
       maxRounds: 12
     }
   },


### PR DESCRIPTION
Scoop install was failing on Windows because the version number & hash value were out of date.
- Updated version number to 0.7.1 (latest) and updated hash value to match.