### PR TITLE
fix: disable menu so Ctrl+W doesn't close app

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -34,6 +34,9 @@ app.on('ready', () => {
 
   // this must be set after window has been created on ubuntu 18.04
   mainWindow.setAlwaysOnTop(alwaysOnTop)
+
+  // remove menu to stop the window being closed on Ctrl+W. See #121
+  mainWindow.setMenu(null)
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
Disabling menu so that Ctrl+W doesn't close app. Fixes #121 