### PR TITLE
Added option to disable always-on-top on breaks

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -56,6 +56,21 @@ ipcMain.on('toggle-alwaysOnTop', (event, arg) => {
   mainWindow.setAlwaysOnTop(arg)
 })
 
+let breakAlwaysOnTop
+
+ipcMain.on('toggle-breakAlwaysOnTop', (event, arg) => {
+  breakAlwaysOnTop = arg
+  if (breakAlwaysOnTop === false) {
+    mainWindow.setAlwaysOnTop(true)
+  }
+})
+
+ipcMain.on('onBreak', (event, arg) => {
+  if (breakAlwaysOnTop === true) {
+    mainWindow.setAlwaysOnTop(!arg)
+  }
+})
+
 ipcMain.on('toggle-minToTray', (event, arg) => {
   if (arg) {
     createTray()

--- a/src/renderer/components/drawer/Drawer-settings.vue
+++ b/src/renderer/components/drawer/Drawer-settings.vue
@@ -9,6 +9,17 @@
         :class="alwaysOnTop ? 'is-active' : 'is-inactive'"
       ></div>
     </div>
+    <transition name="slide-left" mode="in-out">
+      <div class="Setting-wrapper" v-show="alwaysOnTop">
+        <p class="Setting-title">Deactivate Always On Top on Breaks</p>
+        <div
+          class="Checkbox"
+          @click="selectBreakAlwaysOnTop"
+          :class="breakAlwaysOnTop ? 'is-active' : 'is-inactive'"
+          ref="breakAlwaysOnTopCheckbox"
+        ></div>
+      </div>
+    </transition>
     <div class="Setting-wrapper">
       <p class="Setting-title">Auto-start Work Timer</p>
       <div
@@ -79,6 +90,10 @@ export default {
       return this.$store.getters.alwaysOnTop
     },
 
+    breakAlwaysOnTop() {
+      return this.$store.getters.breakAlwaysOnTop
+    },
+
     autoStartWorkTimer() {
       return this.$store.getters.autoStartWorkTimer
     },
@@ -119,6 +134,21 @@ export default {
         val: !this.alwaysOnTop
       }
       ipcRenderer.send('toggle-alwaysOnTop', !this.alwaysOnTop)
+      this.$store.dispatch('setSetting', payload)
+      this.$store.dispatch('setViewState', payload)
+
+      if (this.alwaysOnTop === false && this.breakAlwaysOnTop === true) {
+        this.$refs.breakAlwaysOnTopCheckbox.click()
+      }
+    },
+
+    selectBreakAlwaysOnTop() {
+      const payload = {
+        key: 'breakAlwaysOnTop',
+        val: !this.breakAlwaysOnTop
+      }
+
+      ipcRenderer.send('toggle-breakAlwaysOnTop', !this.breakAlwaysOnTop)
       this.$store.dispatch('setSetting', payload)
       this.$store.dispatch('setViewState', payload)
     },

--- a/src/renderer/components/timer/Timer-controller.vue
+++ b/src/renderer/components/timer/Timer-controller.vue
@@ -3,7 +3,7 @@
 <script>
 import { EventBus } from '@/utils/EventBus'
 import { logger } from '@/utils/logger'
-
+import { ipcRenderer } from 'electron'
 export default {
   computed: {
     // store getters
@@ -35,21 +35,25 @@ export default {
         this.$store.dispatch('incrementTotalWorkRounds')
         EventBus.$emit('ready-long-break')
         logger.info('focus round completed')
+        ipcRenderer.send('onBreak', true)
       } else if (this.currentRound === 'work') {
         this.$store.dispatch('setCurrentRound', 'short-break')
         this.$store.dispatch('incrementTotalWorkRounds')
         EventBus.$emit('ready-short-break')
         logger.info('focus round completed')
+        ipcRenderer.send('onBreak', true)
       } else if (this.currentRound === 'short-break') {
         this.$store.dispatch('setCurrentRound', 'work')
         this.$store.dispatch('incrementRound')
         EventBus.$emit('ready-work')
         logger.info('short break completed')
+        ipcRenderer.send('onBreak', false)
       } else if (this.currentRound === 'long-break') {
         this.$store.dispatch('setCurrentRound', 'work')
         this.$store.dispatch('resetRound')
         EventBus.$emit('ready-work')
         logger.info('long break completed')
+        ipcRenderer.send('onBreak', false)
       }
       this.dispatchTimer()
     },

--- a/src/renderer/store/modules/View.js
+++ b/src/renderer/store/modules/View.js
@@ -12,6 +12,7 @@ const state = {
       ? true
       : localStore.get('autoStartBreakTimer'),
   alwaysOnTop: localStore.get('alwaysOnTop'),
+  breakAlwaysOnTop: localStore.get('breakAlwaysOnTop'),
   minToTray: localStore.get('minToTray'),
   minToTrayOnClose: localStore.get('minToTrayOnClose'),
   notifications: localStore.get('notifications'),
@@ -38,6 +39,10 @@ const getters = {
 
   alwaysOnTop() {
     return state.alwaysOnTop
+  },
+
+  breakAlwaysOnTop() {
+    return state.breakAlwaysOnTop
   },
 
   minToTray() {

--- a/src/renderer/utils/LocalStore.js
+++ b/src/renderer/utils/LocalStore.js
@@ -13,6 +13,7 @@ export const defaults = generateSettings()
 function generateSettings() {
   return {
     alwaysOnTop: false,
+    breakAlwaysOnTop: false,
     autoStartWorkTimer: true,
     autoStartBreakTimer: true,
     minToTray: false,


### PR DESCRIPTION
This pull request fixes issue #116 
I have added an option in the settings to disable always-on-top during breaks. The option will disappear when always-on-top is disabled. Whenever the current round changes, the Timer-controller will tell the main process to change the always-on-top status of the window according to what the current round is.