### PR TITLE
optimize cpu usage by reducing the timer redraw frequency

### DIFF
--- a/src/renderer/components/timer/Timer-dial.vue
+++ b/src/renderer/components/timer/Timer-dial.vue
@@ -132,7 +132,11 @@ export default {
       this.dial = anime({
         targets: '.Dial-fill path',
         strokeDashoffset: [anime.setDashoffset, 0],
-        easing: 'linear',
+        easing: function(el, i, total) {
+          return function(t) {
+            return t.toFixed(3)
+          }
+        },
         duration: duration,
         direction: 'reverse',
         autoplay: false


### PR DESCRIPTION
I noticed that when the timer is started, animejs causes electron to redraw the main window at 60FPS rate.
Such speed doesn't come for free and results into very a high CPU usage on many systems 

This PR replaces `easing: "linear"` with a [custom easing function](https://animejs.com/documentation/#customEasing) that reduces precision of returned "progress" to 3 digits (thus resulting into 1000 of redraws per full timer cycle)
I guess it should also fix #135

I also noticed that disabling hardware acceleration allows to save some extra CPU usage (Ubuntu 20.04 with Intel graphics). Probably might be a good idea to add such an option into the settings dialog. 