### PR TITLE
Feature: Enabled option to exit application directly from taskbar tray.

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -150,16 +150,14 @@ function toggleWindow() {
   }
 }
 
-const Menu = require('electron')
-
 function createTray() {
   const trayIconFile =
     process.platform === 'darwin' ? 'icon--macos--tray.png' : 'icon.png'
   tray = new Tray(path.join(__static, trayIconFile))
   tray.setToolTip('Pomotroid\nClick to Restore')
-  const contextMenu = Menu.buildFromTemplate([
+  const contextMenu = electron.Menu.buildFromTemplate([
     {
-      label: 'Show',
+      label: 'View',
       click: function() {
         toggleWindow()
       }
@@ -172,6 +170,9 @@ function createTray() {
       }
     }
   ])
+  tray.on('click', () => {
+    toggleWindow()
+  })
   tray.setContextMenu(contextMenu)
 }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -150,14 +150,29 @@ function toggleWindow() {
   }
 }
 
+const Menu = require('electron')
+
 function createTray() {
   const trayIconFile =
     process.platform === 'darwin' ? 'icon--macos--tray.png' : 'icon.png'
   tray = new Tray(path.join(__static, trayIconFile))
   tray.setToolTip('Pomotroid\nClick to Restore')
-  tray.on('click', () => {
-    toggleWindow()
-  })
+  const contextMenu = Menu.buildFromTemplate([
+    {
+      label: 'Show',
+      click: function() {
+        toggleWindow()
+      }
+    },
+    {
+      label: 'Exit',
+      click: function() {
+        app.isQuiting = true
+        app.quit()
+      }
+    }
+  ])
+  tray.setContextMenu(contextMenu)
 }
 
 function createWindow() {


### PR DESCRIPTION
This feature update allows users to exit the application directly from the taskbar tray instead of launching it and then closing it.
When the feature "Minimize to Tray on Close" is enabled, the only way to close the application was to launch it first and then close it by right-clicking on the application from the taskbar and then exiting it. 
Or by using task manager or the terminal. With this feature update, it's a lot easier to exit the application.

Additional options, such as start, pause, and reset can also be added to the tray menu options with ease.

![image](https://user-images.githubusercontent.com/54742586/118010886-0e709b00-b36d-11eb-8f77-ebd1f85c510a.png)

Fixes #166.
