### PR TITLE
✨ create a setting that makes the app initialize when the system starts

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -37,8 +37,9 @@ app.whenReady().then(() => {
   createWindow()
   const minToTray = localStore.get('minToTray')
   const alwaysOnTop = localStore.get('alwaysOnTop')
+  const openOnStart = localStore.get('openOnStart')
 
-  if (minToTray) {
+  if (minToTray || openOnStart) {
     createTray()
   }
 
@@ -47,6 +48,10 @@ app.whenReady().then(() => {
 
   // remove menu to stop the window being closed on Ctrl+W. See #121
   mainWindow.setMenu(null)
+
+  if (openOnStart) {
+    mainWindow.hide()
+  }
 
   // load shortcuts from storage
   loadGlobalShortcuts(localStore.get('globalShortcuts'))
@@ -117,6 +122,13 @@ ipcMain.on('reload-global-shortcuts', (event, shortcuts) => {
   logger.info('reload global shortcuts')
   globalShortcut.unregisterAll()
   loadGlobalShortcuts(shortcuts)
+})
+
+ipcMain.on('open-on-start', (event, status) => {
+  electron.app.setLoginItemSettings({
+    openAtLogin: status,
+    path: electron.app.getPath('exe')
+  })
 })
 
 function getNewWindowPosition() {

--- a/src/renderer/components/drawer/Drawer-settings.vue
+++ b/src/renderer/components/drawer/Drawer-settings.vue
@@ -76,6 +76,14 @@
         :class="minToTrayOnClose ? 'is-active' : 'is-inactive'"
       ></div>
     </div>
+    <div class="Setting-wrapper">
+      <p class="Setting-title">Open when system starts</p>
+      <div
+        class="Checkbox"
+        @click="selectOpenOnStart"
+        :class="openOnStart ? 'is-active' : 'is-inactive'"
+      ></div>
+    </div>
 
     <p class="Drawer-heading">Global Shortcuts</p>
 
@@ -133,6 +141,10 @@ export default {
 
     minToTrayOnClose() {
       return this.$store.getters.minToTrayOnClose
+    },
+
+    openOnStart() {
+      return this.$store.getters.openOnStart
     },
 
     notifications() {
@@ -215,6 +227,16 @@ export default {
         key: 'minToTrayOnClose',
         val: !this.minToTrayOnClose
       }
+      this.$store.dispatch('setSetting', payload)
+      this.$store.dispatch('setViewState', payload)
+    },
+
+    selectOpenOnStart() {
+      const payload = {
+        key: 'openOnStart',
+        val: !this.openOnStart
+      }
+      ipcRenderer.send('open-on-start', !this.openOnStart)
       this.$store.dispatch('setSetting', payload)
       this.$store.dispatch('setViewState', payload)
     },

--- a/src/renderer/store/modules/View.js
+++ b/src/renderer/store/modules/View.js
@@ -15,6 +15,7 @@ const state = {
   breakAlwaysOnTop: localStore.get('breakAlwaysOnTop'),
   minToTray: localStore.get('minToTray'),
   minToTrayOnClose: localStore.get('minToTrayOnClose'),
+  openOnStart: localStore.get('openOnStart'),
   notifications: localStore.get('notifications'),
   os: process.platform,
   theme: localStore.get('theme') || 'Pomotroid'
@@ -51,6 +52,10 @@ const getters = {
 
   minToTrayOnClose() {
     return state.minToTrayOnClose
+  },
+
+  openOnStart() {
+    return state.openOnStart
   },
 
   notifications() {

--- a/src/renderer/utils/LocalStore.js
+++ b/src/renderer/utils/LocalStore.js
@@ -18,6 +18,7 @@ function generateSettings() {
     autoStartBreakTimer: true,
     minToTray: false,
     minToTrayOnClose: false,
+    openOnStart: false,
     notifications: true,
     workRounds: 4,
     theme: null,


### PR DESCRIPTION
This PR creates a new setting called "openOnStart" that when enabled, the app will be launched when the OS starts.
It was only tested on Windows but according to the documentation this should work on other systems too.