### PR TITLE
chore(dev-deps): replace node-sass with sass so that app works on nod…

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "mini-css-extract-plugin": "^0.11.0",
     "multispinner": "^0.2.1",
     "node-loader": "^0.6.0",
-    "node-sass": "^4.14.1",
+    "sass": "^1.66.1",
     "sass-loader": "^8.0.2",
     "style-loader": "^1.2.1",
     "url-loader": "^4.1.1",


### PR DESCRIPTION
This update fixes [#259](https://github.com/Splode/pomotroid/issues/259). I have removed `node-sass` with `sass` package which is the correct package to use going forward.

Ref:- https://sass-lang.com/blog/libsass-is-deprecated/