### PR TITLE
feat: add Crimson White theme

### DIFF
--- a/src-tauri/src/themes/mod.rs
+++ b/src-tauri/src/themes/mod.rs
@@ -33,6 +33,7 @@ const BUNDLED_JSON: &[&str] = &[
     include_str!("../../../static/themes/catppuccin-mocha.json"),
     include_str!("../../../static/themes/city-lights.json"),
     include_str!("../../../static/themes/cobalt2.json"),
+    include_str!("../../../static/themes/crimson-white.json"),
     include_str!("../../../static/themes/dracula.json"),
     include_str!("../../../static/themes/darcula.json"),
     include_str!("../../../static/themes/dva.json"),
@@ -167,7 +168,7 @@ mod tests {
     #[test]
     fn all_bundled_themes_parse() {
         let themes = load_bundled();
-        assert_eq!(themes.len(), 37, "expected 37 bundled themes");
+        assert_eq!(themes.len(), 38, "expected 38 bundled themes");
     }
 
     #[test]
@@ -198,6 +199,15 @@ mod tests {
         assert!(
             themes.iter().any(|t| t.name == "Pomotroid"),
             "Pomotroid theme must be bundled"
+        );
+    }
+
+    #[test]
+    fn crimson_white_theme_is_bundled() {
+        let themes = load_bundled();
+        assert!(
+            themes.iter().any(|t| t.name == "Crimson White"),
+            "Crimson White theme must be bundled"
         );
     }
 }

--- a/static/themes/crimson-white.json
+++ b/static/themes/crimson-white.json
@@ -1,0 +1,15 @@
+{
+  "name": "Crimson White",
+  "colors": {
+    "--color-long-round": "#e05252",
+    "--color-short-round": "#f28b82",
+    "--color-focus-round": "#c0392b",
+    "--color-background": "#ffffff",
+    "--color-background-light": "#f5f5f5",
+    "--color-background-lightest": "#e8e8e8",
+    "--color-foreground": "#2c2c2c",
+    "--color-foreground-darker": "#555555",
+    "--color-foreground-darkest": "#888888",
+    "--color-accent": "#a31515"
+  }
+}


### PR DESCRIPTION
A clean white background theme with red accent colors, inspired by the tomato color palette of Pomodoro.

- Focus round: deep crimson red (#c0392b)
- Short break: soft rose (#f28b82)
- Long break: warm red (#e05252)
- Background: pure white with light gray layers
- Accent: dark red (#a31515)

- Added `static/themes/crimson-white.json`
- Registered theme in `src-tauri/src/themes/mod.rs`
- Updated bundled theme count assertion (37 → 38)
- Added dedicated test `crimson_white_theme_is_bundled`