### PR TITLE
fix: prevent crash when enabling system tray on KDE Plasma 6 / Wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 [Unreleased]
 -----------
 
+### Bug Fixes
+
+* **App freeze / crash on launch when "Show in System Tray" is enabled on KDE Plasma 6 / Wayland** — enabling the system tray on a Linux system without `libayatana-appindicator3` or `libappindicator3` installed caused `libappindicator-sys` to panic inside an `extern "C"` function, which aborts the process. Because the setting is persisted before the crash, every subsequent launch would abort before the window could appear. The fix probes for the shared library via `dlopen` before calling `TrayIconBuilder::build()` and returns early with a warning when it is absent. The System Tray section in Settings → System is now hidden entirely on Linux systems where the library is not found, preventing the setting from being enabled in the first place. The required library can be installed on Arch / Manjaro with `sudo pacman -S libayatana-appindicator`.
+
 ### UI
 
 * **Collapsible theme pickers** — the Light Theme and Dark Theme pickers in Settings → Appearance are now collapsible rows instead of two permanently expanded lists. Each row shows the configured theme name and a color chip (round-type swatches on the theme's own background color) when collapsed. Clicking a row expands its full theme list; opening one automatically closes the other. A checkmark marks the selected theme in either picker regardless of which mode is currently active.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -175,8 +175,19 @@ pub fn settings_set(
 
     // Create or destroy the tray when tray_icon_enabled or min_to_tray changes.
     // The tray exists when either flag is true.
+    // On Linux, spawn tray creation on a background thread to avoid blocking
+    // the main thread on KDE Plasma 6 / Wayland (D-Bus StatusNotifier hang).
     if matches!(key.as_str(), "tray_icon_enabled" | "min_to_tray") {
         if new_settings.tray_icon_enabled || new_settings.min_to_tray {
+            #[cfg(target_os = "linux")]
+            {
+                let app_handle = app.clone();
+                let ts = Arc::clone(&tray_state);
+                std::thread::spawn(move || {
+                    tray::create_tray(&app_handle, &ts);
+                });
+            }
+            #[cfg(not(target_os = "linux"))]
             tray::create_tray(&app, &tray_state);
         } else {
             tray::destroy_tray(&tray_state);
@@ -578,6 +589,21 @@ pub fn accessibility_trusted() -> bool {
         unsafe { AXIsProcessTrusted() }
     }
     #[cfg(not(target_os = "macos"))]
+    {
+        true
+    }
+}
+
+/// Returns whether the system tray is supported on this platform/install.
+/// On Linux, probes for libayatana-appindicator3 / libappindicator3 at runtime.
+/// On macOS and Windows, always returns true.
+#[tauri::command]
+pub fn tray_supported() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        tray::appindicator_available()
+    }
+    #[cfg(not(target_os = "linux"))]
     {
         true
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ use tauri_plugin_log::{Builder as LogBuilder, RotationStrategy, Target, TargetKi
 
 use commands::{
     accessibility_trusted,
+    tray_supported,
     app_version,
     check_update,
     install_update,
@@ -139,7 +140,22 @@ pub fn run() {
 
             // Create initial tray icon if tray_icon_enabled is on, or if an
             // existing user has min_to_tray enabled (backwards compatibility).
+            //
+            // On Linux, TrayIconBuilder::build() can block the main thread
+            // indefinitely on KDE Plasma 6 / Wayland while waiting for the
+            // StatusNotifierWatcher D-Bus service to respond.  Spawning on a
+            // background thread lets setup() return so the event loop starts
+            // and the window can appear while the tray registers asynchronously.
             if initial_settings.tray_icon_enabled || initial_settings.min_to_tray {
+                #[cfg(target_os = "linux")]
+                {
+                    let app_handle = app.handle().clone();
+                    let ts = Arc::clone(&tray_state);
+                    std::thread::spawn(move || {
+                        tray::create_tray(&app_handle, &ts);
+                    });
+                }
+                #[cfg(not(target_os = "linux"))]
                 tray::create_tray(app.handle(), &tray_state);
             }
 
@@ -329,6 +345,7 @@ pub fn run() {
             open_log_dir,
             get_log_dir,
             accessibility_trusted,
+            tray_supported,
             app_version,
             // Updater
             check_update,

--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -7,6 +7,14 @@
 ///
 /// Colors come from the active theme, updated when theme changes.
 /// The tray is created/destroyed when `min_to_tray` setting changes.
+///
+/// ## Linux / Wayland note
+/// Tauri's tray support on Linux is backed by `libappindicator-sys`, which
+/// `dlopen`s `libayatana-appindicator3` or `libappindicator3` at runtime and
+/// panics (aborting the process) if neither is found.  KDE Plasma 6 on Wayland
+/// typically does not ship these libraries.  `create_tray` probes for them
+/// before calling `TrayIconBuilder::build()` and returns early with a warning
+/// when they are absent, preventing the abort.
 use std::f32::consts::{FRAC_PI_2, PI, TAU};
 use std::sync::{Arc, Mutex};
 
@@ -124,6 +132,61 @@ impl TrayState {
 // Tray lifecycle
 // ---------------------------------------------------------------------------
 
+/// Check whether the appindicator shared library is loadable on this system.
+///
+/// `libappindicator-sys` panics with an unrecoverable abort when none of the
+/// four candidate `.so` names can be opened.  We probe via `dlopen` first so
+/// `create_tray` can return gracefully instead of crashing the process.
+///
+/// KDE Plasma 6 on Wayland typically does not ship these libraries.
+#[cfg(target_os = "linux")]
+pub(crate) fn appindicator_available() -> bool {
+    use std::ffi::c_char;
+    extern "C" {
+        fn dlopen(filename: *const c_char, flags: i32) -> *mut std::ffi::c_void;
+        fn dlclose(handle: *mut std::ffi::c_void) -> i32;
+    }
+    const RTLD_LAZY: i32 = 0x0001;
+    // Mirror the four names tried by libappindicator-sys 0.9.
+    let candidates: &[&[u8]] = &[
+        b"libayatana-appindicator3.so.1\0",
+        b"libappindicator3.so.1\0",
+        b"libayatana-appindicator3.so\0",
+        b"libappindicator3.so\0",
+    ];
+    log::debug!("[tray] probing for appindicator shared library");
+    let result = candidates.iter().find_map(|name| unsafe {
+        let name_str = std::str::from_utf8(name)
+            .unwrap_or("?")
+            .trim_end_matches('\0');
+        log::debug!("[tray] trying {name_str}");
+        let handle = dlopen(name.as_ptr() as *const c_char, RTLD_LAZY);
+        if !handle.is_null() {
+            dlclose(handle);
+            Some(name_str)
+        } else {
+            None
+        }
+    });
+    match result {
+        Some(found) => {
+            log::info!("[tray] appindicator found: {found}");
+            true
+        }
+        None => {
+            log::warn!(
+                "[tray] appindicator not found — checked: {}",
+                candidates
+                    .iter()
+                    .map(|n| std::str::from_utf8(n).unwrap_or("?").trim_end_matches('\0'))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+            false
+        }
+    }
+}
+
 /// Show the system tray icon.
 ///
 /// If the icon has already been created (e.g. it was previously hidden), it is
@@ -138,6 +201,19 @@ pub fn create_tray(app: &AppHandle, state: &Arc<TrayState>) {
             log::info!("[tray] shown (reused existing icon)");
             return;
         }
+    }
+
+    // On Linux, libappindicator-sys aborts the process if neither
+    // libayatana-appindicator3 nor libappindicator3 is installed (common on
+    // KDE Plasma 6 / Wayland).  Bail out gracefully if the probe fails.
+    #[cfg(target_os = "linux")]
+    if !appindicator_available() {
+        log::warn!(
+            "[tray] libayatana-appindicator3 / libappindicator3 not found — \
+             system tray is unavailable on this system. \
+             Install libayatana-appindicator3 to enable it."
+        );
+        return;
     }
 
     let toggle_item = match MenuItem::with_id(app, "toggle", "Start", true, None::<&str>) {

--- a/src/lib/components/settings/sections/SystemSection.svelte
+++ b/src/lib/components/settings/sections/SystemSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
   import { settings } from '$lib/stores/settings';
-  import { setSetting, resetSettings, clearSessionHistory } from '$lib/ipc';
+  import { setSetting, resetSettings, clearSessionHistory, traySupported } from '$lib/ipc';
   import SettingsToggle from '$lib/components/settings/SettingsToggle.svelte';
   import * as m from '$paraglide/messages.js';
   import { setLocale } from '$lib/locale.svelte.js';
@@ -18,6 +19,14 @@
     { value: 'pt',   label: 'Português' },
     { value: 'tr',   label: 'Türkçe' },
   ];
+
+  // On Linux, probe for libayatana-appindicator3 at runtime.  The tray section
+  // is hidden entirely when the library is absent so users can't enable a
+  // feature that would crash the app.  Non-Linux platforms always support tray.
+  let trayAvailable = $state(!isLinux);
+  onMount(async () => {
+    if (isLinux) trayAvailable = await traySupported();
+  });
 
   let localPort = $state(String($settings.websocket_port));
   $effect(() => { localPort = String($settings.websocket_port); });
@@ -157,36 +166,38 @@
     onclick={() => toggle('verbose_logging', $settings.verbose_logging)}
   />
 
-  <div class="group-heading">{m.system_group_tray()}</div>
+  {#if trayAvailable}
+    <div class="group-heading">{m.system_group_tray()}</div>
 
-  <!-- Show in System Tray: available on all platforms. -->
-  <SettingsToggle
-    label={m.system_toggle_show_tray()}
-    description={m.system_toggle_show_tray_desc()}
-    tooltip={isLinux ? m.system_tray_gnome_hint() : undefined}
-    checked={$settings.tray_icon_enabled}
-    onclick={() => toggle('tray_icon_enabled', $settings.tray_icon_enabled)}
-  />
+    <!-- Show in System Tray: available on all platforms. -->
+    <SettingsToggle
+      label={m.system_toggle_show_tray()}
+      description={m.system_toggle_show_tray_desc()}
+      tooltip={isLinux ? m.system_tray_gnome_hint() : undefined}
+      checked={$settings.tray_icon_enabled}
+      onclick={() => toggle('tray_icon_enabled', $settings.tray_icon_enabled)}
+    />
 
-  {#if $settings.tray_icon_enabled}
-    <!-- Minimize to Tray is Windows/Linux only: the macOS yellow traffic-light
-         button routes to the Dock and cannot be intercepted by the app. -->
-    {#if !isMac}
+    {#if $settings.tray_icon_enabled}
+      <!-- Minimize to Tray is Windows/Linux only: the macOS yellow traffic-light
+           button routes to the Dock and cannot be intercepted by the app. -->
+      {#if !isMac}
+        <SettingsToggle
+          label={m.system_toggle_min_tray()}
+          description={m.system_toggle_min_tray_desc()}
+          checked={$settings.min_to_tray}
+          onclick={() => toggle('min_to_tray', $settings.min_to_tray)}
+        />
+      {/if}
+      <!-- Close to Tray is available on all platforms: the CloseRequested event
+           fires on macOS (red button / Cmd+W) and can be intercepted. -->
       <SettingsToggle
-        label={m.system_toggle_min_tray()}
-        description={m.system_toggle_min_tray_desc()}
-        checked={$settings.min_to_tray}
-        onclick={() => toggle('min_to_tray', $settings.min_to_tray)}
+        label={m.system_toggle_close_tray()}
+        description={m.system_toggle_close_tray_desc()}
+        checked={$settings.min_to_tray_on_close}
+        onclick={() => toggle('min_to_tray_on_close', $settings.min_to_tray_on_close)}
       />
     {/if}
-    <!-- Close to Tray is available on all platforms: the CloseRequested event
-         fires on macOS (red button / Cmd+W) and can be intercepted. -->
-    <SettingsToggle
-      label={m.system_toggle_close_tray()}
-      description={m.system_toggle_close_tray_desc()}
-      checked={$settings.min_to_tray_on_close}
-      onclick={() => toggle('min_to_tray_on_close', $settings.min_to_tray_on_close)}
-    />
   {/if}
 
   <div class="group-heading">{m.system_group_window()}</div>

--- a/src/lib/ipc/index.ts
+++ b/src/lib/ipc/index.ts
@@ -84,6 +84,11 @@ export const statsGetHeatmap = () => invoke<HeatmapStats>('stats_get_heatmap');
 
 export const accessibilityTrusted = () => invoke<boolean>('accessibility_trusted');
 
+/** Returns true if the system tray is usable on this platform/install.
+ *  On Linux this probes for libayatana-appindicator3 / libappindicator3 at
+ *  runtime; on macOS and Windows it always returns true. */
+export const traySupported = () => invoke<boolean>('tray_supported');
+
 // --- Updater commands ---
 
 /** Check for an available update. Returns update info or null if already up to date. */


### PR DESCRIPTION
On Linux systems without libayatana-appindicator3 or libappindicator3 installed (common on KDE Plasma 6 / Wayland), libappindicator-sys panics inside an extern "C" function when TrayIconBuilder::build() is called. Because the panic cannot unwind, the process aborts. Since tray_icon_enabled is persisted to SQLite before the crash, every subsequent launch also aborts before the window appears.

Fix: probe for the shared library via dlopen before calling TrayIconBuilder::build(). If none of the four candidate .so names are loadable, create_tray returns early with a warning log instead of aborting the process.

To prevent the setting from being enabled on unsupported systems, the System Tray section in Settings > System is now hidden on Linux when the probe fails. A new tray_supported IPC command exposes the probe result to the frontend, called once on mount in SystemSection.

The library can be installed on Arch / Manjaro with:
`sudo pacman -S libayatana-appindicator`

Resolves #380 