### PR TITLE
fix: restore tray-hidden windows

### DIFF
--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -128,6 +128,20 @@ impl TrayState {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrayWindowAction {
+    Hide,
+    Restore,
+}
+
+fn tray_window_action(is_visible: bool, is_minimized: bool) -> TrayWindowAction {
+    if is_visible && !is_minimized {
+        TrayWindowAction::Hide
+    } else {
+        TrayWindowAction::Restore
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tray lifecycle
 // ---------------------------------------------------------------------------
@@ -268,14 +282,17 @@ pub fn create_tray(app: &AppHandle, state: &Arc<TrayState>) {
             {
                 let app = tray_icon.app_handle();
                 if let Some(window) = app.get_webview_window("main") {
-                    match window.is_visible() {
-                        Ok(true) => {
+                    let visible = window.is_visible().unwrap_or(false);
+                    let minimized = window.is_minimized().unwrap_or(false);
+                    match tray_window_action(visible, minimized) {
+                        TrayWindowAction::Hide => {
                             log::debug!("[tray] left-click → hide");
                             let _ = window.hide();
                         }
-                        _ => {
+                        TrayWindowAction::Restore => {
                             log::debug!("[tray] left-click → show");
                             let _ = window.show();
+                            let _ = window.unminimize();
                             let _ = window.set_focus();
                         }
                     }
@@ -303,6 +320,7 @@ pub fn create_tray(app: &AppHandle, state: &Arc<TrayState>) {
                     log::info!("[tray] show");
                     if let Some(window) = app.get_webview_window("main") {
                         let _ = window.show();
+                        let _ = window.unminimize();
                         let _ = window.set_focus();
                     }
                 }
@@ -552,5 +570,20 @@ mod tests {
         assert_eq!(parse_hex_color("not-a-color"), None);
         assert_eq!(parse_hex_color("#ZZZ"), None);
         assert_eq!(parse_hex_color(""), None);
+    }
+
+    #[test]
+    fn tray_click_hides_visible_unminimized_window() {
+        assert_eq!(tray_window_action(true, false), TrayWindowAction::Hide);
+    }
+
+    #[test]
+    fn tray_click_restores_minimized_window() {
+        assert_eq!(tray_window_action(true, true), TrayWindowAction::Restore);
+    }
+
+    #[test]
+    fn tray_click_restores_hidden_window() {
+        assert_eq!(tray_window_action(false, false), TrayWindowAction::Restore);
     }
 }

--- a/src/lib/components/Titlebar.svelte
+++ b/src/lib/components/Titlebar.svelte
@@ -8,6 +8,17 @@
   import * as m from '$paraglide/messages.js';
 
   let maximized = $state(false);
+  let suppressTitlebarHover = $state(false);
+
+  function blurTitlebarControl() {
+    const active = document.activeElement;
+    if (active instanceof HTMLElement && active.closest('.titlebar')) active.blur();
+  }
+
+  function suppressRestoredTitlebarState() {
+    suppressTitlebarHover = true;
+    blurTitlebarControl();
+  }
 
   onMount(() => {
     const win = getCurrentWebviewWindow();
@@ -17,8 +28,18 @@
     const unlisten = win.onResized(async () => {
       maximized = await win.isMaximized();
     });
+    const clearRestoredTitlebarFocus = () => {
+      if (suppressTitlebarHover) requestAnimationFrame(blurTitlebarControl);
+    };
+    const clearSuppressedTitlebarHover = () => {
+      suppressTitlebarHover = false;
+    };
+    window.addEventListener('focus', clearRestoredTitlebarFocus);
+    document.addEventListener('pointermove', clearSuppressedTitlebarHover);
     return () => {
       unlisten.then((fn) => fn());
+      window.removeEventListener('focus', clearRestoredTitlebarFocus);
+      document.removeEventListener('pointermove', clearSuppressedTitlebarHover);
     };
   });
 
@@ -67,6 +88,7 @@
   }
 
   async function minimize() {
+    suppressRestoredTitlebarState();
     if ($settings.min_to_tray) {
       await setWindowVisibility(false);
     } else {
@@ -78,8 +100,9 @@
     getCurrentWebviewWindow().toggleMaximize();
   }
 
-  function close() {
-    getCurrentWebviewWindow().close();
+  async function close() {
+    suppressRestoredTitlebarState();
+    await getCurrentWebviewWindow().close();
   }
 </script>
 
@@ -155,7 +178,7 @@
   </Tooltip>
 {/snippet}
 
-<nav class="titlebar" data-tauri-drag-region>
+<nav class="titlebar" class:suppress-hover={suppressTitlebarHover} data-tauri-drag-region>
   <!-- Left: settings + stats buttons on Linux/Windows. On macOS the traffic
        lights live here; the action buttons move to the right side instead. -->
   {#if !isMac}
@@ -223,7 +246,11 @@
           </svg>
         {/if}
       </button>
-      <button class="btn-icon close" onclick={close} aria-label="Close">
+      <button
+        class="btn-icon close"
+        onclick={close}
+        aria-label="Close"
+      >
         <svg width="12" height="12" viewBox="0 0 12 12">
           <line
             x1="1"
@@ -283,12 +310,21 @@
       background 0.15s;
   }
 
-  .btn-icon:hover {
+  .btn-icon:focus {
+    outline: none;
+  }
+
+  .btn-icon:focus-visible {
+    outline: 2px solid color-mix(in oklch, var(--color-foreground) 45%, transparent);
+    outline-offset: 2px;
+  }
+
+  .titlebar:not(.suppress-hover) .btn-icon:hover {
     color: var(--color-foreground);
     background: var(--color-hover);
   }
 
-  .btn-icon.close:hover {
+  .titlebar:not(.suppress-hover) .btn-icon.close:hover {
     color: var(--color-background);
     background: var(--color-focus-round);
   }


### PR DESCRIPTION
## Summary

This fixes two tray-related window restore issues:

- Restores the main window correctly when it is minimized but still reported as visible.
- Clears stale titlebar hover/focus state after restoring the window from the tray.

## Problem

When system tray support and close-to-tray are enabled, but minimize-to-tray is disabled, the main window can enter states that are not handled correctly by the current tray restore logic.

### Case 1: minimized window does not restore from tray

Configuration:

- Always on top: enabled
- System tray: enabled
- Close to tray: enabled
- Minimize to tray: disabled

Steps:

1. Minimize the main window.
2. Click the tray icon.

Expected:

The main window should be restored and focused.

Actual:

The window may remain hidden/minimized because the tray click handler only checks `is_visible()`. On some platforms a minimized window can still be reported as visible, so the handler chooses `hide()` instead of restore.

### Case 2: close button remains visually selected after tray restore

Configuration:

- Always on top: enabled
- System tray: enabled
- Close to tray: enabled
- Minimize to tray: disabled

Steps:

1. Click the window close button.
2. The window is hidden to tray.
3. Click the tray icon to restore it.

Expected:

The restored window should not keep the close button in a hover/focus-like visual state, and pressing Enter should not trigger the previously focused close button.

Actual:

The close button can remain visually highlighted/red after restore, and the focused control state is not cleared.

## Changes

- Adds a small `TrayWindowAction` decision helper that treats minimized windows as restore targets.
- Restores hidden/minimized windows with `show()`, `unminimize()`, and `set_focus()`.
- Applies the same restore behavior to the tray menu `Show` action.
- Adds unit tests for the tray click decision matrix.
- Clears stale titlebar focus/hover state before minimizing or closing.
- Suppresses titlebar hover visuals until the user moves the pointer again after restore.
- Keeps keyboard focus visibility via `:focus-visible`.

## Testing

Tested manually on Windows:

- Minimize the window, then click the tray icon: the window restores correctly.
- Close to tray, then click the tray icon: the window restores without the close button staying red/selected.
- Pressing Enter after restore no longer closes the window via stale close-button focus.

Commands run:

```bash
cargo test --manifest-path src-tauri/Cargo.toml tray_click
npm run check
```