### PR TITLE
feat: show tray menu only on right click

### DIFF
--- a/src-tauri/src/tray/mod.rs
+++ b/src-tauri/src/tray/mod.rs
@@ -258,6 +258,7 @@ pub fn create_tray(app: &AppHandle, state: &Arc<TrayState>) {
         .icon(image)
         .tooltip("Pomotroid")
         .menu(&menu)
+        .show_menu_on_left_click(false)
         .on_tray_icon_event(|tray_icon, event| {
             // Left-click: toggle window visibility.
             if let TrayIconEvent::Click {


### PR DESCRIPTION
 ## Summary

  This updates the tray icon interaction so left click toggles the main window visibility, while the tray context menu is reserved for
  right click.

  ## Background

  Discussed in #405.

  The proposed behavior matches the more common Windows tray pattern:

  - Left click: show/hide the main window
  - Right click: open the tray menu

  ## Changes

  - Adds `.show_menu_on_left_click(false)` to the tray icon builder.
  - Keeps the existing left-click window visibility toggle.
  - Keeps the tray menu available through right click.

  ## Testing

  Tested manually on Windows:

  - Left-clicking the tray icon restores the main window.
  - Left-clicking the tray icon again hides the main window.
  - Left-clicking the tray icon does not open the tray menu.
  - Right-clicking the tray icon opens the tray menu.

  ## Platform notes

  As noted in #405:

  - macOS may ignore `show_menu_on_left_click(false)` because tray/menu-bar click behavior is often controlled by the OS.
  - Linux AppIndicator behavior may vary by desktop environment and may not consistently distinguish left/right click. 