### PR TITLE
fix: prevent timer from getting stuck after skip or restart

### DIFF
--- a/src-tauri/src/timer/engine.rs
+++ b/src-tauri/src/timer/engine.rs
@@ -23,6 +23,9 @@ pub enum TimerCommand {
     Skip,
     /// Change the total duration; moves engine to Idle so caller must Start.
     Reconfigure { duration_secs: u32 },
+    /// Update the stored duration without altering phase or elapsed time.
+    /// Used to arm the next round/reset path without clobbering a fresh Start.
+    Prime { duration_secs: u32 },
     /// OS sleep detected: freeze elapsed position, block until WakeResume.
     Suspend,
     /// OS wake detected: resume from the saved elapsed position.
@@ -123,10 +126,14 @@ fn run_loop(
                     total_secs = d;
                     Transition::Stay
                 }
+                Ok(TimerCommand::Prime { duration_secs: d }) => {
+                    total_secs = d;
+                    Transition::Stay
+                }
                 // Reset while Idle: emit the event so the listener can update
-                // the frontend and send a follow-up Reconfigure.  Without this
-                // handler the command would be silently swallowed, leaving the
-                // listener blocked in recv() and the UI stale.
+                // the frontend and then sync the next-round duration. Without
+                // this handler the command would be silently swallowed,
+                // leaving the listener blocked in recv() and the UI stale.
                 Ok(TimerCommand::Reset) => {
                     elapsed_secs = 0;
                     let _ = event_tx.send(TimerEvent::Reset);
@@ -165,6 +172,10 @@ fn run_loop(
                     total_secs = d;
                     elapsed_secs = 0;
                     Transition::To(Phase::Idle)
+                }
+                Ok(TimerCommand::Prime { duration_secs: d }) => {
+                    total_secs = d;
+                    Transition::Stay
                 }
                 Ok(TimerCommand::Shutdown) | Err(_) => Transition::Break,
                 _ => Transition::Stay,
@@ -217,6 +228,10 @@ fn run_loop(
                         total_secs = d;
                         elapsed_secs = 0;
                         Transition::To(Phase::Idle)
+                    }
+                    Ok(TimerCommand::Prime { duration_secs: d }) => {
+                        total_secs = d;
+                        Transition::Stay
                     }
                     Ok(TimerCommand::Shutdown) => Transition::Break,
                     _ => Transition::Stay,
@@ -485,6 +500,27 @@ mod tests {
         assert!(
             matches!(events.last(), Some(TimerEvent::Complete { .. })),
             "last event must be Complete after reconfigured timer"
+        );
+    }
+
+    #[test]
+    fn prime_updates_duration_without_cancelling_fresh_start() {
+        // Models the skip/reset race: the UI sends Start for the next round
+        // before the listener's follow-up duration update reaches the engine.
+        let (handle, rx) = spawn(10, TICK);
+        handle.send(TimerCommand::Start);
+        std::thread::sleep(TICK / 2);
+        handle.send(TimerCommand::Prime { duration_secs: 3 });
+
+        let events = collect_until_complete(&rx, Duration::from_secs(2));
+        let ticks = events
+            .iter()
+            .filter(|e| matches!(e, TimerEvent::Tick { .. }))
+            .count();
+        assert_eq!(ticks, 3, "Prime to 3s should keep the timer running and yield 3 ticks, got {ticks}");
+        assert!(
+            matches!(events.last(), Some(TimerEvent::Complete { .. })),
+            "last event must be Complete after priming a fresh start"
         );
     }
 

--- a/src-tauri/src/timer/mod.rs
+++ b/src-tauri/src/timer/mod.rs
@@ -139,9 +139,8 @@ impl TimerController {
         log::info!("[timer] reset");
         self.sequence.lock().unwrap().reset();
         // Send only Reset — the event listener's Reset handler will follow up
-        // with Reconfigure once the engine is confirmed Idle.  Sending
-        // Reconfigure here first would push the engine into Idle before Reset
-        // arrives, causing Reset to be silently dropped and the UI to freeze.
+        // with Prime once the engine is confirmed Idle. Sending a duration
+        // update here first would race the Reset and can leave the UI stale.
         self.engine.send(TimerCommand::Reset);
     }
 
@@ -330,8 +329,9 @@ fn listen_events(
                     s.is_running = false;
                 }
 
-                // Prepare the engine for the next round.
-                engine.send(TimerCommand::Reconfigure {
+                // Arm the next round's duration without risking a late
+                // reconfigure that kicks a freshly-started timer back to Idle.
+                engine.send(TimerCommand::Prime {
                     duration_secs: next_duration,
                 });
 
@@ -455,18 +455,17 @@ fn listen_events(
                     websocket::broadcast_reset(&ws);
                 }
 
-                // Reconfigure the engine with the current round's duration so
-                // the next Start uses the correct (possibly settings-updated)
-                // total.  This is safe here because the engine is guaranteed
-                // to be in Idle when it emits Reset (all three phases —
-                // Running, Paused, and now Idle — transition to/stay Idle
-                // before sending the event).
+                // Prime the engine with the current round's duration so the
+                // next Start uses the correct (possibly settings-updated)
+                // total. Using the lighter-weight command here avoids a race
+                // where a fast user click on Start is immediately clobbered by
+                // a late follow-up duration update.
                 let duration = {
                     let seq = sequence.lock().unwrap();
                     let s = settings.lock().unwrap();
                     seq.current_duration_secs(&s)
                 };
-                engine.send(TimerCommand::Reconfigure { duration_secs: duration });
+                engine.send(TimerCommand::Prime { duration_secs: duration });
 
                 // Reset tray to idle (empty arc).
                 let rt = sequence.lock().unwrap().current_round.as_str().to_string();


### PR DESCRIPTION
## Issue

Timer can get stuck after skipping or restarting round. After that, pressing start/play may do nothing.

## Cause

After `skip` or `reset`, timer listener sends a follow-up `Reconfigure` to load next round duration.

If user starts next round before that command lands, `Reconfigure` can arrive while engine is already running and force it back to `Idle`.

That leaves engine state out of sync with UI and makes timer appear stuck.

## Fix

Add a lightweight `Prime` command to timer engine.

`Prime` updates stored duration for next round without changing engine phase.

Use `Prime` instead of `Reconfigure` in post-`Complete` and post-`Reset` paths, so next-round duration is updated without interrupting a fresh start.