### PR TITLE
Bugfix/disable webview context menu

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  onMount(() => {
+    const disableContextMenu = (event: MouseEvent) => {
+      event.preventDefault();
+    };
+
+    document.addEventListener('contextmenu', disableContextMenu, { capture: true });
+
+    return () => {
+      document.removeEventListener('contextmenu', disableContextMenu, { capture: true });
+    };
+  });
+</script>
+
+<slot />


### PR DESCRIPTION
  ## Summary

  - Disable the default webview/browser context menu across the app
  - Prevent right-click from showing actions like Save As, Print, and Inspect-style browser options

  ## Why

  Pomotroid is a desktop app, so the default browser context menu feels out of place when right-clicking the app window.

  This also avoids conflict with future app-specific context menus, such as a possible timer widget menu.

  ## Test plan

  - `npm run check`
  - `npm run build`
